### PR TITLE
Convert preprint link in README to use MD instead of LaTeX

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The conference publication about the alpha version of MEDFORD is hosted on Polin
 
 Reproducibility of research is essential for science. However, in the way modern computational biology research is done, it is easy to lose track of small, but extremely critical, details. Key details, such as the specific version of a software used or iteration of a genome can easily be lost in the shuffle, or perhaps not noted at all. Much work is being done on the database and storage side of things, ensuring that there exists a space to store experiment-specific details, but current mechanisms for recording details are cumbersome for scientists to use. We propose a new metadata description language, named MEDFORD, in which scientists can record [or encode!] all details relevant to their research. Human-readable, easily-editable, and templatable, MEDFORD serves as a collection point for all notes that a researcher could find relevant to their research, be it for internal use or for future replication. MEDFORD has been applied to coral research, documenting research from RNA-seq analyses to photo collectionsHuman-readible metadata file format to consolidate research information such that it can be stored, updated, and submitted to databases without introducing a huge time investment overhead.
 
-A preprint of a journal version of the MEDFORD paper is on the arXiv at \url{https://arxiv.org/abs/2204.09610}.
+A preprint of a journal version of the MEDFORD paper is on the arXiv at https://arxiv.org/abs/2204.09610.
 
 ## Contributions & Thanks
 Contributors to the development of MEDFORD are as follows:


### PR DESCRIPTION
The `\url{}` command is displayed in the README otherwise. The URL will render as a hyperlink in the README markdown file without any additional syntax.