### PR TITLE
Add Additional Data to Syntax Error Objects

### DIFF
--- a/src/MEDFORD/medford_error_mngr.py
+++ b/src/MEDFORD/medford_error_mngr.py
@@ -31,6 +31,7 @@ class mfd_unexpected_macro(mfd_syntax_err):
 class mfd_duplicated_macro(mfd_syntax_err):
     def __init__(self, instance_1:int, instance_2:int, macro_name:str) :
         self.substr = macro_name
+        self.earlier_lineno = instance_1
         message = f"Duplicated macro '{macro_name}' on lines {instance_1} and {instance_2}."
         super().__init__(message, instance_2, "duplicated_macro", False, True)
 
@@ -41,6 +42,7 @@ class mfd_remaining_template(mfd_syntax_err):
 
 class mfd_no_desc(mfd_syntax_err):
     def __init__(self, lineno:int, major_token:str):
+        self.substr = major_token
         message = f"Novel token @{major_token} started without a description on line {lineno}."
         super().__init__(message, lineno, "no_desc", False, True)
 


### PR DESCRIPTION
This PR adds some data members to the `mfd_duplicated_macro` and the `mfd_no_desc` syntax errors so that the [language server](https://github.com/liam-strand/medford-language-server) doesn't need to regex through the error string to find them.

They were added in the same style as the ones for `mfd_unexpected_macro`, so there isn't any change to the public API.