### PR TITLE
typo: Association not Assocation

### DIFF
--- a/src/MEDFORD/medford_models.py
+++ b/src/MEDFORD/medford_models.py
@@ -67,7 +67,7 @@ class Date(BaseModel):
 
 class Contributor(StrDescModel) :
     ORCID: OptDataT[int]
-    Assocation: OptDataT[str]
+    Association: OptDataT[str]
     Role: OptDataT[str]
     Email: OptDataT[str] #TODO: Email validation
 


### PR DESCRIPTION
In `medford_models.py`, the first `i` in `association` is omitted in the definition of the Contributor major token.

I discovered this as we are parsing the class structure of the `Entity` object to extract the major/minor token relationships, so this spelling error jumped out when we applied the new syntax highlighting to old files.