### PR TITLE
remember if we removed an inline comment before reporting empty lines

### DIFF
--- a/src/MEDFORD/medford_detail.py
+++ b/src/MEDFORD/medford_detail.py
@@ -123,10 +123,12 @@ class detail() :
         :rtype: Tuple(Bool, Bool, Detail)
         """
         line = line.strip()
+        comment_removed = False
         
         # Line contains a comment
         if detail.comment_flag in line :
             line = detail._remove_inline_comment(line)
+            comment_removed = True
 
         # Line is empty
         if(len(line) == 0) :
@@ -157,7 +159,7 @@ class detail() :
         # Line follows the standard major-minor format
         elif line[0] == "@" :
             if len(str.split(line, " ")) == 1 :
-                err_mngr.add_syntax_err(mfd_empty_line(lineno, True, str.split(line, " ")[0]))
+                err_mngr.add_syntax_err(mfd_empty_line(lineno, comment_removed, str.split(line, " ")[0]))
                 return previous_return
             tokens, body = str.split(line, " ", 1)
             tokens = str.replace(tokens, '@', "")


### PR DESCRIPTION
This makes it so that the reports for empty content react to the presence of a comment in the original line. For example:
```
@Contributor Tony Monaco
@Contributor-Role
```
gives 
> No content provided on line 44, only tokens: @Contributor-Role.

while
```
@Contributor Tony Monaco
@Contributor-Role # President
```
gives
> No content provided on line 44, only tokens: @Contributor-Role. An inline comment was found on this line -- did you mean to make it a comment?
