### PR TITLE
Fix Crash When No Contributor is Provided

### DIFF
--- a/src/MEDFORD/medford.py
+++ b/src/MEDFORD/medford.py
@@ -211,5 +211,10 @@ def parse_args_and_go() :
     mfd = MFD(PurePath(args.file))
     mfd.run_medford()
 
+def provide_args_and_go(action:ParserMode, file:str, mode:OutputMode, debug:bool = False) :
+    mfdglobals.debug = debug
+    mfd = MFD(PurePath(file))
+    mfd.run_medford()
+
 if __name__ == "__main__" :
     parse_args_and_go()

--- a/src/MEDFORD/models/generics.py
+++ b/src/MEDFORD/models/generics.py
@@ -71,7 +71,7 @@ class RoleOpts(Flag) :
 # Attributes                                #
 #############################################
 
-class MEDFORDmdl(BlockModel) :
+class MEDFORDMDL(BlockModel) :
     """Model to store MEDFORD metadata describing the MEDFORD file itself,
      such as MEDFORD file colloqiual name and the version of MEDFORD used
      to write this file."""
@@ -96,18 +96,18 @@ class MEDFORDmdl(BlockModel) :
         return values
     
 
-class Journal(BlockModel):
+class JournalMDL(BlockModel):
     name: MinorT[str]
     #TODO: Validation? Do we care about proper format for this?
     Volume: OptMinorT[str]
     Issue: OptMinorT[str]
     Pages: OptMinorT[str]
 
-class Date(BlockModel):
+class DateMDL(BlockModel):
     name: Union[MinorT[datetime.date], MinorT[datetime.datetime]]
     Note: OptMinorT[str]
     
-class Contributor(BlockModel) :
+class ContributorMDL(BlockModel) :
     name: MinorT[str]
     ORCID: OptMinorT[str] = None
     Association: OptMinorT[str] = None
@@ -152,11 +152,11 @@ class Contributor(BlockModel) :
 
         return cur_flags
 
-class Funding(BlockModel):
+class FundingMDL(BlockModel):
     ID: OptMinorT[str]
     # TODO: research possible funding IDs so we can implement validation
 
-class Keyword(BlockModel):
+class KeywordMDL(BlockModel):
     pass
 
 
@@ -166,5 +166,5 @@ class Keyword(BlockModel):
 #############################################
 
 class Entity(BaseModel) :
-    MEDFORD: MajorsT[MEDFORDmdl]
-    Contributor: OptMajorT[Contributor]
+    MEDFORD: MajorsT[MEDFORDMDL]
+    Contributor: OptMajorT[ContributorMDL] = None

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,27 @@
+from MEDFORD.medford import provide_args_and_go, ParserMode, OutputMode
+
+# example error case:
+# no Contributor tag -> crash
+
+# error 1 : leading tabs are not deleted.
+# error 2 : removing contributor causes it to crash.
+def test_no_contributor(tmp_path) :
+    example_content = "\
+@MEDFORD asdf\n\
+@MEDFORD-Version 2.0\n\
+\n\
+@Journal journal\n\
+"
+    
+    d = tmp_path / "tmp_testfiles"
+    d.mkdir()
+    tmpfile = d / "only_MEDFORD.mfd"
+    tmpfile.write_text(example_content, encoding="utf-8")
+    
+    print(example_content)
+    with open(tmpfile) as f:
+        print(f.readlines())
+
+
+    provide_args_and_go(ParserMode.VALIDATE, tmpfile, OutputMode.OTHER)
+    return


### PR DESCRIPTION
Contributor was added as an example of an optional minor token, and yet Pydantic was throwing a validation error when it was not provided, stating that Contributor is required. This bug has been solved by adding the default value `None` to the Contributor attribute, such that pydantic correctly recognizes it as optional.

```python
class Entity(BaseModel) :
    MEDFORD: MajorsT[MEDFORDMDL]
    Contributor: OptMajorT[ContributorMDL]
```

became: 

```python
class Entity(BaseModel) :
    MEDFORD: MajorsT[MEDFORDMDL]
    Contributor: OptMajorT[ContributorMDL] = None
```

This PR also deconvolutes attributes and their custom times (e.g. `Contributor` became `ContributorMDL`) to prevent further issues from the name overlap.