### PR TITLE
Strip leading (and tailing) whitespace

### DIFF
--- a/src/MEDFORD/objs/linereader.py
+++ b/src/MEDFORD/objs/linereader.py
@@ -179,6 +179,8 @@ class LineReader :
         Currently only returns None in the case of an At-At line (which are currently being ignored entirely) or if the line is empty."""
         if line.strip() == "" :
             return None
+        
+        line = line.strip()
 
         if LineReader.is_comment_line(line) :
             return CommentLine(lineno, line)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -17,11 +17,22 @@ def test_no_contributor(tmp_path) :
     d.mkdir()
     tmpfile = d / "only_MEDFORD.mfd"
     tmpfile.write_text(example_content, encoding="utf-8")
-    
-    print(example_content)
-    with open(tmpfile) as f:
-        print(f.readlines())
 
+    provide_args_and_go(ParserMode.VALIDATE, tmpfile, OutputMode.OTHER)
+    return
+
+def test_lead_spacing_ignored(tmp_path) :
+    example_content = "\
+        @MEDFORD asdf\n\
+        @MEDFORD-Version 2.0\n\
+        \n\
+        @Journal journal\n\
+        "
+    
+    d = tmp_path / "tmp_testfiles"
+    d.mkdir()
+    tmpfile = d / "only_MEDFORD.mfd"
+    tmpfile.write_text(example_content, encoding="utf-8")
 
     provide_args_and_go(ParserMode.VALIDATE, tmpfile, OutputMode.OTHER)
     return

--- a/tests/test_obj_linecollector.py
+++ b/tests/test_obj_linecollector.py
@@ -576,3 +576,49 @@ class TestLineCollection() :
         assert lc.named_blocks['Contributor']['Kiki Shpilker'] == block_2
 
         assert lc.comments == [comment_1, comment_2, comment_3]
+
+    #############################
+    # Test get_content features #
+    #############################
+
+    def test_twoline_spacing(self) :
+        test_lines = ["@Contributor Polina Shpilker","@Contributor-Association Tufts ", " University"]
+        test_Lines : List[Optional[Line]] = []
+
+        for idx, l in enumerate(test_lines) :
+            test_Lines.append(LineReader.process_line(l, idx))
+
+        confirmed_lines : List[Line] = []
+        for idx, L in enumerate(test_Lines) :
+            assert L is not None
+            confirmed_lines.append(L)
+
+        lc : LineCollector = LineCollector(confirmed_lines)
+
+        assert list(lc.named_blocks.keys()) == ["Contributor"]
+        assert list(lc.named_blocks['Contributor'].keys()) == ["Polina Shpilker"]
+
+        ex_block:Block = lc.named_blocks['Contributor']['Polina Shpilker']
+        ex_detail:Detail = ex_block.details[1]
+        assert ex_detail.get_raw_content() == "Tufts University"
+
+    def test_twoline_tab_spacing(self) :
+        test_lines = ["@Contributor Polina Shpilker","\t@Contributor-Association\t Tufts ", " University"]
+        test_Lines : List[Optional[Line]] = []
+
+        for idx, l in enumerate(test_lines) :
+            test_Lines.append(LineReader.process_line(l, idx))
+
+        confirmed_lines : List[Line] = []
+        for idx, L in enumerate(test_Lines) :
+            assert L is not None
+            confirmed_lines.append(L)
+
+        lc : LineCollector = LineCollector(confirmed_lines)
+
+        assert list(lc.named_blocks.keys()) == ["Contributor"]
+        assert list(lc.named_blocks['Contributor'].keys()) == ["Polina Shpilker"]
+
+        ex_block:Block = lc.named_blocks['Contributor']['Polina Shpilker']
+        ex_detail:Detail = ex_block.details[1]
+        assert ex_detail.get_raw_content() == "Tufts University"


### PR DESCRIPTION
In `linereader.py`, empty lines were tested for using the following block:
```python
        if line.strip() == "" :
            return None
```

Then, the line is not stripped and continues being processed. This causes issues when there is whitespace at the head of the line, which should technically be valid. As an example, the test `test_lead_spacing_ignored` tests the following string, which originally caused the linereader to fail:

```python
    example_content = "\
        @MEDFORD asdf\n\
        @MEDFORD-Version 2.0\n\
        \n\
        @Journal journal\n\
        "
```

The following line has been added to `linereader.py` resolve this:
```python
line = line.strip()
```

Tests were added to `test_obj_linecollector.py` to ensure that this does not affect the output of `get_content` from a detail. That is, if the following MEDFORD is provided (with at signs stripped so GitHub doesn't tag anyone):
```
contributor-association Tufts   
  University
```
... it correctly results in `Tufts University` when the detail is asked for its contents, no matter the spacing in the original MEDFORD line.