### PR TITLE
Only Allow Leading Whitespace for Comments

### DIFF
--- a/src/MEDFORD/objs/linereader.py
+++ b/src/MEDFORD/objs/linereader.py
@@ -46,7 +46,8 @@ class LineReader :
     # Novel token
     @staticmethod
     def is_comment_line(line:str) -> bool :
-        """Returns True if the provided string is a comment line."""
+        """Returns True if the provided string is a comment line. Ignores leading spaces."""
+        line = line.strip()
         return re.match(f"{DetailStatics.comment_header}", line) is not None
 
     @staticmethod
@@ -179,8 +180,6 @@ class LineReader :
         Currently only returns None in the case of an At-At line (which are currently being ignored entirely) or if the line is empty."""
         if line.strip() == "" :
             return None
-        
-        line = line.strip()
 
         if LineReader.is_comment_line(line) :
             return CommentLine(lineno, line)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,4 +1,5 @@
 from MEDFORD.medford import provide_args_and_go, ParserMode, OutputMode
+import pytest
 
 # example error case:
 # no Contributor tag -> crash
@@ -21,7 +22,7 @@ def test_no_contributor(tmp_path) :
     provide_args_and_go(ParserMode.VALIDATE, tmpfile, OutputMode.OTHER)
     return
 
-def test_lead_spacing_ignored(tmp_path) :
+def test_lead_spacing_not_ignored(tmp_path) :
     example_content = "\
         @MEDFORD asdf\n\
         @MEDFORD-Version 2.0\n\
@@ -34,5 +35,6 @@ def test_lead_spacing_ignored(tmp_path) :
     tmpfile = d / "only_MEDFORD.mfd"
     tmpfile.write_text(example_content, encoding="utf-8")
 
-    provide_args_and_go(ParserMode.VALIDATE, tmpfile, OutputMode.OTHER)
+    with pytest.raises(ValueError) :
+        provide_args_and_go(ParserMode.VALIDATE, tmpfile, OutputMode.OTHER)
     return

--- a/tests/test_obj_linereader.py
+++ b/tests/test_obj_linereader.py
@@ -140,6 +140,16 @@ def test_detect_macro_badcurly() :
     assert res is not None
     assert isinstance(res, NovelDetailLine)
     assert res.has_macros
+
+def test_creating_comment_line() :
+    example_lines = [" # Comment Line"]
+    a = CommentLine(0,example_lines[0])
+    assert a.line == " # Comment Line"
+
+    b = LineReader.process_line(example_lines[0],0)
+    assert type(b) is CommentLine
+    assert b.line == " # Comment Line"
+    
 # TODO : move tests over from test_linereader to test "find" capabilities
 # TODO : add test for major-minor identification
 # TODO : add raw content setting tests (e.g. mname, mbody)


### PR DESCRIPTION
Sort-of reverts TuftsBCB/medford#21

We determined that leading whitespaces should not be stripped as it adds ambiguity in macro definition/usage (which is another issue that is being more concretely worked on.) Whitespace is no longer being stripped, and the `comment` recognition now allows for leading whitespace before the `#` character. The leading whitespace test has been adjusted, and a test has been added to ensure comments work as expected.