### PR TITLE
Added build date tag to the --out output of medford files

### DIFF
--- a/src/MEDFORD/__init__.py
+++ b/src/MEDFORD/__init__.py
@@ -361,6 +361,12 @@ class MFD:
     def _get_line_objects(cls, filename: str) -> List[Line]:
         with open(filename, "r", encoding="utf-8") as f:
             raw_lines = f.readlines()
+        
+        # Previously, the parser wasn't handling the underscores infront of
+        # the @__BUILD_DATE tag correctly, causing it to crash on re-compilation
+        # Strip any @__BUILD_DATE lines so that re-compiling an --out file
+        # does not crash the parser (the tag is re-written by OutWriter).
+        raw_lines = [ln for ln in raw_lines if not ln.lstrip().startswith("@__BUILD_DATE")]
         expanded_lines = expand_templates(raw_lines)
         object_lines = []
         for idx, line in enumerate(expanded_lines):

--- a/src/MEDFORD/objs/linecollections.py
+++ b/src/MEDFORD/objs/linecollections.py
@@ -173,13 +173,6 @@ class Macro(LineCollection):
         else:
             cdepth: int = depth
 
-<<<<<<< HEAD
-=======
-        # debug print
-        #print(self.name)
-        #print(cdepth)
-
->>>>>>> origin/dev
         if self._is_resolved:
             return self.resolution
 

--- a/src/MEDFORD/objs/outwriter.py
+++ b/src/MEDFORD/objs/outwriter.py
@@ -1,5 +1,6 @@
 # src/MEDFORD/objs/outwriter.py
 
+import datetime
 from typing import Dict, Optional, Any, List
 
 
@@ -50,6 +51,10 @@ class OutWriter:
 
         return "\n".join(lines)
 
+    def _is_build_date_block(self, block: Any) -> bool:
+        tokens = getattr(block, "major_tokens", None)
+        return bool(tokens and len(tokens) == 1 and tokens[0] == "__BUILD_DATE")
+
     def write_blocks(
         self,
         blocks: List[Any],
@@ -65,6 +70,11 @@ class OutWriter:
         - Then write block
         - Finally write trailing comments
         """
+        # Remove any pre-existing @__BUILD_DATE block so it is not duplicated on recompilation
+        blocks = [b for b in blocks if not self._is_build_date_block(b)]
+        # Generate UTC datetime string
+        build_date = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+
         comments = list(getattr(self.line_collector, "comments", []) or [])
 
         def _cln(x: Any) -> int:
@@ -105,11 +115,14 @@ class OutWriter:
 
             def write_block_text(text: str):
                 """"
-                Splits a block's text on newlines and writes each line 
+                Splits a block's text on newlines and writes each line
                 separately to preserve blank lines and how we track them for sep() purposes.
                 """
                 for line in text.splitlines():
                     write_line(line)
+
+            # Put  build date as the very first tag in at the top of the file
+            write_line(f"@__BUILD_DATE {build_date}")
 
             for b in blocks:
                 b_start = self._block_start_lineno(b)

--- a/tests/test_out.py
+++ b/tests/test_out.py
@@ -26,6 +26,14 @@ def _normalize(s: str) -> str:
     lines = [ln.rstrip() for ln in s.strip().splitlines()]
     return "\n".join(lines)
 
+
+def _normalize_no_builddate(s: str) -> str:
+    """Like _normalize but strips @__BUILD_DATE lines so idempotency checks
+    are not broken by the timestamp changing between runs."""
+    lines = [ln.rstrip() for ln in s.strip().splitlines()
+             if not ln.startswith("@__BUILD_DATE")]
+    return "\n".join(lines)
+
 # --- tests -----------------------------------------------------
 
 # Test that --out creates a file with content
@@ -56,8 +64,8 @@ def test_out_writes_file(tmp_path):
     text = out_path.read_text(encoding="utf-8")
     assert text.strip() != "", "output file is unexpectedly empty"
 
-    # (Optional) sanity check: first line still looks MEDFORD-y
-    assert text.splitlines()[0].startswith("@MEDFORD")
+    # check: first line is the build date tag
+    assert text.splitlines()[0].startswith("@__BUILD_DATE")
 
 
 # Tests that --out is idempotent with a small file (compiling the output file again produces the same file)
@@ -90,8 +98,9 @@ def test_out_idempotent_smallfile(tmp_path):
     # Read the output file after the second run
     final_text = out_path.read_text(encoding="utf-8")
 
-    # Assert: The content remains unchanged after the second run
-    assert _normalize(first_run) == _normalize(final_text), "Output file content changed after second run"
+    # Content (excluding the build date, which changes each run) is unchanged after the second run
+    assert _normalize_no_builddate(first_run) == _normalize_no_builddate(final_text), \
+        "Output file content changed after second run"
 
 # Tests that --out is idempotent with a large file (compiling the output file again produces the same file)
 def test_out_idempotent_largefile(tmp_path):
@@ -118,8 +127,9 @@ def test_out_idempotent_largefile(tmp_path):
     # Read the output file after the second run
     final_text = out_path.read_text(encoding="utf-8")
 
-    # Assert: The content remains unchanged after the second run
-    assert _normalize(first_run) == _normalize(final_text), "Output file content changed after second run"
+    # Content (excluding the build date, which changes each run) is unchanged after the second run
+    assert _normalize_no_builddate(first_run) == _normalize_no_builddate(final_text), \
+        "Output file content changed after second run"
 
 # Tests for invalid --out path handling
 def test_out_invalid_path(tmp_path):
@@ -159,11 +169,11 @@ def test_out_with_macros(tmp_path):
         `@reef_photo REEF_X_PHOTO_
 
         # Call the macros
-        @Photo `@{reef_photo}01
+        @Photo `{reef_photo}01
 
-        @Photo `@{reef_photo}02
+        @Photo `{reef_photo}02
 
-        @Photo `@{reef_photo}03
+        @Photo `{reef_photo}03
         """
 
     input_path = tmp_path / "input_with_macros.mfd"
@@ -196,11 +206,11 @@ def test_out_with_macros_idempotent(tmp_path):
         `@reef_photo REEF_X_PHOTO_
 
         # Call the macros
-        @Photo `@{reef_photo}01
+        @Photo `{reef_photo}01
 
-        @Photo `@{reef_photo}02
+        @Photo `{reef_photo}02
 
-        @Photo `@{reef_photo}03
+        @Photo `{reef_photo}03
         """
 
     input_path = tmp_path / "input_with_macros.mfd"
@@ -222,5 +232,74 @@ def test_out_with_macros_idempotent(tmp_path):
 
     final_text = out_path.read_text(encoding="utf-8")
 
-    # Assert: The content remains unchanged after the second run
-    assert _normalize(first_run) == _normalize(final_text), "Output file content changed after second run with macros"
+    # Content (excluding the build date, which changes each run) is unchanged after the second run
+    assert _normalize_no_builddate(first_run) == _normalize_no_builddate(final_text), \
+        "Output file content changed after second run with macros"
+
+
+# Tests that --out writes @__BUILD_DATE as the first line with a UTC timestamp
+def test_out_build_date_present(tmp_path):
+    sample = textwrap.dedent("""\
+        @MEDFORD description
+        @MEDFORD-Version 1.0
+
+        @Title Build Date Test
+        @Contributor Jane Doe
+    """)
+
+    input_path = tmp_path / "input.mfd"
+    input_path.write_text(sample, encoding="utf-8")
+    out_path = tmp_path / "out.mfd"
+
+    code, _, stderr = _run_medford_compile(input_path, str(out_path))
+    assert code == 0, f"compile failed:\n{stderr}"
+
+    lines = out_path.read_text(encoding="utf-8").splitlines()
+
+    # First line must be the build date tag
+    assert lines[0].startswith("@__BUILD_DATE"), \
+        f"Expected @__BUILD_DATE as first line, got: {lines[0]!r}"
+
+    # The build date line must end with " UTC"
+    assert lines[0].endswith("UTC"), \
+        f"Build date line does not end with UTC: {lines[0]!r}"
+
+
+# Tests that re-compiling an --out file replaces the old build date rather than duplicating it
+def test_out_build_date_overwritten(tmp_path):
+    import time
+
+    sample = textwrap.dedent("""\
+        @MEDFORD description
+        @MEDFORD-Version 1.0
+
+        @Title Overwrite Test
+        @Contributor Jane Doe
+    """)
+
+    input_path = tmp_path / "input.mfd"
+    input_path.write_text(sample, encoding="utf-8")
+    out_path = tmp_path / "out.mfd"
+
+    # First compile
+    code1, _, stderr1 = _run_medford_compile(input_path, str(out_path))
+    assert code1 == 0, f"first compile failed:\n{stderr1}"
+    first_date_line = out_path.read_text(encoding="utf-8").splitlines()[0]
+
+    # Adding some delay so the timestamp is guaranteed to differ
+    time.sleep(1.1)
+
+    # Second compile using the output of the first compile as input
+    code2, _, stderr2 = _run_medford_compile(out_path, str(out_path))
+    assert code2 == 0, f"second compile failed:\n{stderr2}"
+
+    text = out_path.read_text(encoding="utf-8")
+    build_date_lines = [ln for ln in text.splitlines() if ln.startswith("@__BUILD_DATE")]
+
+    # Only one build date tag must exist
+    assert len(build_date_lines) == 1, \
+        f"Expected exactly 1 @__BUILD_DATE line, found {len(build_date_lines)}: {build_date_lines}"
+
+    # The date must have been updated
+    assert build_date_lines[0] != first_date_line, \
+        "Build date was not updated on recompilation"


### PR DESCRIPTION
# Key Additions
* When a medford file is compiled with --out, the first line of the output file now has @__BUILD_DATE <timestamp UTC> as the first tag.
* When a medford file with a build date tag is recompiled, the old build date is replaced.

# Notes and Changes to Files
## src/MEDFORD/objs/outwriter.py
* write_blocks() now generates a new UTC timesstamp and places it as the very first tag in a compiled medford output.
## src/MEDFORD/ init.py
* Encountered an issue where the underscore before a build date tag were causing the parser to crash on re-compilation. Now _get_line_objects strips @__BUILD_DATE from the raw input before it reaches the parser. This allows the OutWriter to place a new @__BUILD_DATE tag cleanly.
## src/MEDFORD/objs/Linecollections.py
* Removed a leftover merge conflict marker. This is most likely also present in dev and dev_tests branches. Will also remove from those.
## tests/test out.py
* Added new tests to confirm build date tag is being placed correctly.
* Updated the compilation idempotence tests by stripping the build date tag prior to compilation since no two files are truly idempotent due to updated timestamp at re-compilation.
* Fixed two macro tests failing due to updated macro usage from the recent PR. The tests were failing because they were using the @ prefix for calls while they're only meant for definitions.
